### PR TITLE
Upgrade to angular-material 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,16 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angular-material</artifactId>
-    <version>0.9.8-SNAPSHOT</version>
+    <version>0.10.0</version>
     <name>angular-material</name>
     <description>WebJar for angular-material</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.9.7</upstream.version>
+        <upstream.version>0.10.0</upstream.version>
         <upstream.url>https://github.com/angular/bower-material/archive/v${upstream.version}.zip</upstream.url>
-        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${version}</destDir>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>
             {
                 "paths": {
@@ -82,7 +82,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/bower-material-${upstream.version}" excludes="modules/" />
+                                    <fileset dir="${project.build.directory}/bower-material-${upstream.version}" excludes="modules/,demos/" />
                                 </move>
                             </target>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angular-material</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.0-SNAPSHOT</version>
     <name>angular-material</name>
     <description>WebJar for angular-material</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
This update also excludes the `demos/` subdirectory from being included
in the jar artifact.